### PR TITLE
fixing deployment by removing expect-error comment

### DIFF
--- a/src/__tests__/middlewares/authenticate.test.ts
+++ b/src/__tests__/middlewares/authenticate.test.ts
@@ -2,7 +2,6 @@ import DatabaseTestHandler from "../../utils/DatabaseTestHandler";
 import mongoose from "mongoose";
 import {Request,Response} from "express"
 import { authenticateAdmin, authenticateUser } from "../../middlewares/authenticate"
-//@ts-expect-error
 import testData from "../assets/testData/testData.json"
 import dotenv from "dotenv";
 


### PR DESCRIPTION
• Removing @ts-expect-error comment on importing .JSON file that caused deployment to fail.