### PR TITLE
fixing bug with deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "test": "SET NODE_ENV=development && jest --detectOpenHandles",
-    "start": "SET NODE_ENV=production && node ./dist/src/app.js",
+    "start": "node ./dist/src/app.js",
     "dev": "SET NODE_ENV=development && nodemon ./dist/src/app.js",
     "prod": "SET NODE_ENV=production && nodemon ./dist/src/app.js",
     "build": "npm i && npm install typescript && npx tsc"

--- a/src/utils/Server.ts
+++ b/src/utils/Server.ts
@@ -33,10 +33,10 @@ function createServer(){
     app.use(express.json());
     app.use(cors());
     
-    if((process.env.NODE_ENV as string).trim() === "development"){
-        app.use(morgan('dev'));
-    }else{
+    if((process.env.NODE_ENV as string).trim() === "production"){
         app.use(morgan('combined'));
+    }else{ 
+        app.use(morgan('dev'));
     }
     
 


### PR DESCRIPTION
- Fixing a bug that occurs when you try to set NODE_ENV which is forbidden to re-set on deployed render service and causing whole deployment to fail and its set by default to "production".